### PR TITLE
Deprecation fix for Symfony 5.4

### DIFF
--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -15,7 +15,7 @@ class EntryFilesTwigExtension extends AbstractExtension
     $this->entrypointRenderer = $entrypointRenderer;
   }
 
-  public function getFunctions()
+  public function getFunctions(): array
   {
     return [
       new TwigFunction('vite_entry_script_tags', [$this, 'renderViteScriptTags'], ['is_safe' => ['html']]),


### PR DESCRIPTION
```
Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Pentatrion\ViteBundle\Twig\EntryFilesTwigExtension" now to avoid errors or add an e
xplicit @return annotation to suppress this message.
```

Symfony 6 is all about adding type declarations, thus not declaring types when extending Symfony has been deprecated in Symfony 5.4.
`Pentatrion\ViteBundle\Twig\EntryFilesTwigExtension::getFunctions` was missing the type declaration which ended up throwing a deprecation. This PR adds the return type to prevent the deprecation notice from being made.