### PR TITLE
Update php minimum version in composer.json to 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^8.0",
         "symfony/asset": "^4.4 || ^5.0 || ^6.0",
         "symfony/config": "^4.4 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
The codebase uses typed properties which are only available in PHP >= 7.4, but the composer.json allows the package to be installed on PHP 7.2 and 7.3.

This PR bumps the minimum version requirement in composer.json to resolve that.