### PR TITLE
PHP-CS-Fixer and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,50 @@
+name: CI
+
+on: [ push, pull_request ]
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-versions: [ '8.0', '8.1' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+
+      - name: Lint PHP
+        run: find -L . -path ./vendor -prune -o -type f -name '*.php' -print0 | xargs -0 -n 1 -P $(nproc) php -l
+
+      - name: Declare variables
+        if: matrix.php-versions == 8.1
+        id: vars
+        run: |
+          echo "::set-output name=composer_cache_dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer
+        if: matrix.php-versions == 8.1
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.vars.outputs.composer_cache_dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install tools
+        if: matrix.php-versions == 8.1
+        run: composer install --no-interaction --no-ansi
+
+      - name: Validate coding standards
+        if: matrix.php-versions == 8.1
+        run: php vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --verbose --diff --dry-run --stop-on-violation --using-cache=no
+
+      - name: Static analysis
+        if: matrix.php-versions == 8.1
+        run: php vendor/bin/phpstan analyse --configuration=phpstan.neon --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - name: Install tools
+      - name: Install dependencies
         if: matrix.php-versions == 8.1
         run: composer install --no-interaction --no-ansi
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.vscode/
 /.local
-.idea
-composer.lock
-vendor
+/.idea
+/composer.lock
+/vendor
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,14 @@
+<?php
+
+$config = new \PhpCsFixer\Config();
+
+$config
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->getFinder()
+    ->in(__DIR__.'/src')
+    ->append([__FILE__])
+;
+
+return $config;

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         }
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.9",
         "phpstan/phpstan": "^1.8"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "symfony/asset": "^4.4 || ^5.0 || ^6.0",
         "symfony/config": "^4.4 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 1
+	paths:
+		- src

--- a/src/Asset/EntrypointRenderer.php
+++ b/src/Asset/EntrypointRenderer.php
@@ -4,54 +4,56 @@ namespace Pentatrion\ViteBundle\Asset;
 
 class EntrypointRenderer
 {
-  private $entrypointsLookup;
-  private $tagRenderer;
+    private $entrypointsLookup;
+    private $tagRenderer;
 
-  private $hasReturnedViteClient = false;
+    private $hasReturnedViteClient = false;
 
-  public function __construct(EntrypointsLookup $entrypointsLookup)
-  {
-    $this->entrypointsLookup = $entrypointsLookup;
-    $this->tagRenderer = new TagRenderer();
-  }
-
-  public function renderScripts(string $entryName, array $options = [])
-  {
-    if (!$this->entrypointsLookup->hasFile()) {
-      return '';
+    public function __construct(EntrypointsLookup $entrypointsLookup)
+    {
+        $this->entrypointsLookup = $entrypointsLookup;
+        $this->tagRenderer = new TagRenderer();
     }
 
-    $scriptTags = [];
-    if (!$this->entrypointsLookup->isProd()) {
-      $viteServer = $this->entrypointsLookup->getViteServer();
-
-      if (!$this->hasReturnedViteClient) {
-        $scriptTags[] = $this->tagRenderer->renderScriptFile($viteServer['origin'] . $viteServer['base'] . '@vite/client');
-        if (isset($options['dependency']) && $options['dependency'] === 'react') {
-          $scriptTags[] = $this->tagRenderer->renderReactRefreshInline($viteServer['origin'] . $viteServer['base']);
+    public function renderScripts(string $entryName, array $options = [])
+    {
+        if (!$this->entrypointsLookup->hasFile()) {
+            return '';
         }
-        $this->hasReturnedViteClient = true;
-      }
-    }
-    foreach ($this->entrypointsLookup->getJSFiles($entryName) as $fileName) {
-      $scriptTags[] = $this->tagRenderer->renderScriptFile($fileName);
-    }
-    return implode('', $scriptTags);
-  }
 
-  public function renderLinks(string $entryName)
-  {
-    if (!$this->entrypointsLookup->hasFile() || !$this->entrypointsLookup->isProd()) {
-      return '';
+        $scriptTags = [];
+        if (!$this->entrypointsLookup->isProd()) {
+            $viteServer = $this->entrypointsLookup->getViteServer();
+
+            if (!$this->hasReturnedViteClient) {
+                $scriptTags[] = $this->tagRenderer->renderScriptFile($viteServer['origin'].$viteServer['base'].'@vite/client');
+                if (isset($options['dependency']) && 'react' === $options['dependency']) {
+                    $scriptTags[] = $this->tagRenderer->renderReactRefreshInline($viteServer['origin'].$viteServer['base']);
+                }
+                $this->hasReturnedViteClient = true;
+            }
+        }
+        foreach ($this->entrypointsLookup->getJSFiles($entryName) as $fileName) {
+            $scriptTags[] = $this->tagRenderer->renderScriptFile($fileName);
+        }
+
+        return implode('', $scriptTags);
     }
 
-    $linkTags = [];
-    foreach ($this->entrypointsLookup->getCSSFiles($entryName) as $fileName) {
-      $linkTags[] = $this->tagRenderer->renderLinkStylesheet($fileName);
+    public function renderLinks(string $entryName)
+    {
+        if (!$this->entrypointsLookup->hasFile() || !$this->entrypointsLookup->isProd()) {
+            return '';
+        }
+
+        $linkTags = [];
+        foreach ($this->entrypointsLookup->getCSSFiles($entryName) as $fileName) {
+            $linkTags[] = $this->tagRenderer->renderLinkStylesheet($fileName);
+        }
+        foreach ($this->entrypointsLookup->getJavascriptDependencies($entryName) as $fileName) {
+            $linkTags[] = $this->tagRenderer->renderLinkPreload($fileName);
+        }
+
+        return implode('', $linkTags);
     }
-    foreach ($this->entrypointsLookup->getJavascriptDependencies($entryName) as $fileName) {
-      $linkTags[] = $this->tagRenderer->renderLinkPreload($fileName);
-    }
-    return implode('', $linkTags);
-  }
 }

--- a/src/Asset/EntrypointsLookup.php
+++ b/src/Asset/EntrypointsLookup.php
@@ -4,66 +4,65 @@ namespace Pentatrion\ViteBundle\Asset;
 
 class EntrypointsLookup
 {
+    private $entriesData;
+    private $fileExist = false;
+    private $isProd;
+    private $viteServer = null;
 
-  private $entriesData;
-  private $fileExist = false;
-  private $isProd;
-  private $viteServer = null;
+    public function __construct($entrypointsFilePath)
+    {
+        if (!file_exists($entrypointsFilePath)) {
+            return;
+        }
+        $this->fileExist = true;
+        $fileInfos = json_decode(file_get_contents($entrypointsFilePath), true);
 
-  public function __construct($entrypointsFilePath)
-  {
-    if (!file_exists($entrypointsFilePath)) {
-      return;
+        $this->isProd = $fileInfos['isProd'];
+        $this->entriesData = $fileInfos['entryPoints'];
+        if (!$this->isProd) {
+            $this->viteServer = $fileInfos['viteServer'];
+        }
     }
-    $this->fileExist = true;
-    $fileInfos = json_decode(file_get_contents($entrypointsFilePath), true);
 
-    $this->isProd = $fileInfos['isProd'];
-    $this->entriesData = $fileInfos['entryPoints'];
-    if (!$this->isProd) {
-      $this->viteServer = $fileInfos['viteServer'];
+    public function hasFile()
+    {
+        return $this->fileExist;
     }
-  }
 
-  public function hasFile()
-  {
-    return $this->fileExist;
-  }
-
-  public function isProd()
-  {
-    return $this->isProd;
-  }
-
-  public function getViteServer()
-  {
-    return $this->viteServer;
-  }
-
-  public function getJSFiles($entryName)
-  {
-    if (isset($this->entriesData[$entryName])) {
-      return $this->entriesData[$entryName]['js'];
-    } else {
-      return [];
+    public function isProd()
+    {
+        return $this->isProd;
     }
-  }
 
-  public function getCSSFiles($entryName)
-  {
-    if (isset($this->entriesData[$entryName])) {
-      return $this->entriesData[$entryName]['css'];
-    } else {
-      return [];
+    public function getViteServer()
+    {
+        return $this->viteServer;
     }
-  }
 
-  public function getJavascriptDependencies($entryName)
-  {
-    if (isset($this->entriesData[$entryName])) {
-      return $this->entriesData[$entryName]['preload'];
-    } else {
-      return [];
+    public function getJSFiles($entryName)
+    {
+        if (isset($this->entriesData[$entryName])) {
+            return $this->entriesData[$entryName]['js'];
+        } else {
+            return [];
+        }
     }
-  }
+
+    public function getCSSFiles($entryName)
+    {
+        if (isset($this->entriesData[$entryName])) {
+            return $this->entriesData[$entryName]['css'];
+        } else {
+            return [];
+        }
+    }
+
+    public function getJavascriptDependencies($entryName)
+    {
+        if (isset($this->entriesData[$entryName])) {
+            return $this->entriesData[$entryName]['preload'];
+        } else {
+            return [];
+        }
+    }
 }

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -8,8 +8,9 @@ class TagRenderer
     {
         $attributes = [
             'src' => $fileName,
-            'type' => 'module'
+            'type' => 'module',
         ];
+
         return sprintf(
             '<script %s></script>',
             $this->convertArrayToAttributes($attributes)
@@ -19,7 +20,7 @@ class TagRenderer
     public function renderReactRefreshInline($devServerUrl)
     {
         return '  <script type="module">
-    import RefreshRuntime from "' . $devServerUrl . '@react-refresh"
+    import RefreshRuntime from "'.$devServerUrl.'@react-refresh"
     RefreshRuntime.injectIntoGlobalHook(window)
     window.$RefreshReg$ = () => {}
     window.$RefreshSig$ = () => (type) => type
@@ -31,8 +32,9 @@ class TagRenderer
     {
         $attributes = [
             'rel' => 'stylesheet',
-            'href' => $fileName
+            'href' => $fileName,
         ];
+
         return sprintf(
             '<link %s>',
             $this->convertArrayToAttributes($attributes)
@@ -43,8 +45,9 @@ class TagRenderer
     {
         $attributes = [
             'rel' => 'modulepreload',
-            'href' => $fileName
+            'href' => $fileName,
         ];
+
         return sprintf(
             '<link %s>',
             $this->convertArrayToAttributes($attributes)
@@ -55,7 +58,7 @@ class TagRenderer
     {
         return implode(' ', array_map(
             function ($key, $value) {
-                if ($value === true) {
+                if (true === $value) {
                     return sprintf('%s', $key);
                 } else {
                     return sprintf('%s="%s"', $key, htmlentities($value));

--- a/src/Asset/ViteAssetVersionStrategy.php
+++ b/src/Asset/ViteAssetVersionStrategy.php
@@ -3,9 +3,9 @@
 namespace Pentatrion\ViteBundle\Asset;
 
 use Exception;
-use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 use Symfony\Component\Asset\Exception\AssetNotFoundException;
 use Symfony\Component\Asset\Exception\RuntimeException;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 
 class ViteAssetVersionStrategy implements VersionStrategyInterface
 {
@@ -16,7 +16,7 @@ class ViteAssetVersionStrategy implements VersionStrategyInterface
 
     /**
      * @param string $entrypointsPath Absolute path to the entrypoints file
-     * @param bool   $strictMode   Throws an exception for unknown paths
+     * @param bool   $strictMode      Throws an exception for unknown paths
      */
     public function __construct(string $entrypointsPath, bool $strictMode = true)
     {
@@ -53,7 +53,7 @@ class ViteAssetVersionStrategy implements VersionStrategyInterface
             try {
                 $this->entrypointsData = json_decode(file_get_contents($this->entrypointsPath), true, flags: \JSON_THROW_ON_ERROR);
             } catch (\JsonException $e) {
-                throw new RuntimeException(sprintf('Error parsing JSON from entrypoints file "%s": ', $this->entrypointsPath) . $e->getMessage(), previous: $e);
+                throw new RuntimeException(sprintf('Error parsing JSON from entrypoints file "%s": ', $this->entrypointsPath).$e->getMessage(), previous: $e);
             }
         }
 
@@ -62,7 +62,7 @@ class ViteAssetVersionStrategy implements VersionStrategyInterface
                 return $this->entrypointsData['assets'][$path];
             }
         } else {
-            return $this->entrypointsData['viteServer']['origin'] . $this->entrypointsData['viteServer']['base'] . $path;
+            return $this->entrypointsData['viteServer']['origin'].$this->entrypointsData['viteServer']['base'].$path;
         }
 
         if ($this->strictMode) {
@@ -84,7 +84,7 @@ class ViteAssetVersionStrategy implements VersionStrategyInterface
         $alternatives = [];
 
         if (is_null($assetsData)) {
-            return  $alternatives;
+            return $alternatives;
         }
 
         foreach ($assetsData as $key => $value) {

--- a/src/Asset/ViteAssetVersionStrategy.php
+++ b/src/Asset/ViteAssetVersionStrategy.php
@@ -66,7 +66,7 @@ class ViteAssetVersionStrategy implements VersionStrategyInterface
         }
 
         if ($this->strictMode) {
-            $message = sprintf('assets "%s" not found in assets file "%s".', $path, $this->assetsPath);
+            $message = sprintf('assets "%s" not found in entrypoints file "%s".', $path, $this->entrypointsPath);
             $alternatives = $this->findAlternatives($path, $this->assetsData);
             if (\count($alternatives) > 0) {
                 $message .= sprintf(' Did you mean one of these? "%s".', implode('", "', $alternatives));

--- a/src/Controller/ViteController.php
+++ b/src/Controller/ViteController.php
@@ -22,7 +22,7 @@ class ViteController
     {
         $response = $this->httpClient->request(
             'GET',
-            $this->viteDevServer . $this->viteBase . $path
+            $this->viteDevServer.$this->viteBase.$path
         );
 
         $content = $response->getContent();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,12 +7,12 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-  public function getConfigTreeBuilder(): TreeBuilder
-  {
-    $treeBuilder = new TreeBuilder('pentatrion_vite');
-    $rootNode = $treeBuilder->getRootNode();
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('pentatrion_vite');
+        $rootNode = $treeBuilder->getRootNode();
 
-    $rootNode
+        $rootNode
       ->children()
         ->scalarNode('base')->defaultValue('/build/')->end()
         ->scalarNode('public_dir')->defaultValue('/public')->end()
@@ -22,10 +22,10 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('host')->defaultValue('localhost')->end()
             ->integerNode('port')->defaultValue(5173)->end()
             ->booleanNode('https')->defaultFalse()->end()
-          ->end()          
+          ->end()
       ->end()
-    ;
+        ;
 
-    return $treeBuilder;
-  }
+        return $treeBuilder;
+    }
 }

--- a/src/DependencyInjection/PentatrionViteExtension.php
+++ b/src/DependencyInjection/PentatrionViteExtension.php
@@ -4,25 +4,24 @@ namespace Pentatrion\ViteBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class PentatrionViteExtension extends Extension
 {
-  public function load(array $configs, ContainerBuilder $container): void
-  {
-    $loader = new YamlFileLoader($container, new FileLocator((__DIR__ . '/../Resources/config')));
-    $loader->load('services.yaml');
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yaml');
 
-    $config = $this->processConfiguration(
-      $this->getConfiguration($configs, $container),
-      $configs
-    );
+        $config = $this->processConfiguration(
+            $this->getConfiguration($configs, $container),
+            $configs
+        );
 
-    $container->setParameter('pentatrion_vite.base', $config['base']);
-    $container->setParameter('pentatrion_vite.public_dir', $config['public_dir']);
-    $server = ($config['server']['https'] ? 'https://' : 'http://') . $config['server']['host'] . ':' . $config['server']['port'];
-    $container->setParameter('pentatrion_vite.server', $server);
-  }
+        $container->setParameter('pentatrion_vite.base', $config['base']);
+        $container->setParameter('pentatrion_vite.public_dir', $config['public_dir']);
+        $server = ($config['server']['https'] ? 'https://' : 'http://').$config['server']['host'].':'.$config['server']['port'];
+        $container->setParameter('pentatrion_vite.server', $server);
+    }
 }

--- a/src/PentatrionViteBundle.php
+++ b/src/PentatrionViteBundle.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Pentatrion\ViteBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PentatrionViteBundle extends Bundle
 {
-  
 }

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -8,28 +8,28 @@ use Twig\TwigFunction;
 
 class EntryFilesTwigExtension extends AbstractExtension
 {
-  private $entrypointRenderer;
+    private $entrypointRenderer;
 
-  public function __construct(EntrypointRenderer $entrypointRenderer)
-  {
-    $this->entrypointRenderer = $entrypointRenderer;
-  }
+    public function __construct(EntrypointRenderer $entrypointRenderer)
+    {
+        $this->entrypointRenderer = $entrypointRenderer;
+    }
 
-  public function getFunctions(): array
-  {
-    return [
+    public function getFunctions(): array
+    {
+        return [
       new TwigFunction('vite_entry_script_tags', [$this, 'renderViteScriptTags'], ['is_safe' => ['html']]),
       new TwigFunction('vite_entry_link_tags', [$this, 'renderViteLinkTags'], ['is_safe' => ['html']]),
     ];
-  }
+    }
 
-  public function renderViteScriptTags(string $entryName, array $options = []): string
-  {
-    return $this->entrypointRenderer->renderScripts($entryName, $options);
-  }
+    public function renderViteScriptTags(string $entryName, array $options = []): string
+    {
+        return $this->entrypointRenderer->renderScripts($entryName, $options);
+    }
 
-  public function renderViteLinkTags(string $entryName, array $options = []): string
-  {
-    return $this->entrypointRenderer->renderLinks($entryName, $options);
-  }
+    public function renderViteLinkTags(string $entryName, array $options = []): string
+    {
+        return $this->entrypointRenderer->renderLinks($entryName, $options);
+    }
 }


### PR DESCRIPTION
This PR adds PHP-CS-Fixer to the project, using the Symfony ruleset.

The main changes to the code are indentation, but there are a couple more controversial ones includes in the Symfony ruleset such as yoda style conditions (true === $value instead of $value === true) - let me know if you want me to update that.

This PR also adds Continuous Integration via GitHub Actions, which runs on every push and every pull request. The CI action will:

* Parse all PHP files for syntax errors (`php -l`)
* Ensure that all PHP code adheres to the php-cs-fixer configuration
* Static analysis with PHPStan - currently only on level 1 but good be increased with a bit of work to the codebase if desired

I'd like to contribute a few more things to this project, but it would be great to see this merged beforehand so that everyone is working towards the same codestyle.