### PR TITLE
Continuous Integration Update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-versions: [ '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0', '8.1' ]
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,13 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.9",
         "phpstan/phpstan": "^1.8"
+    },
+    "scripts": {
+        "cs-fix": "@php vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php",
+        "ci-check": [
+            "find -L . -path ./vendor -prune -o -type f -name '*.php' -print0 | xargs -0 -n 1 -P $(nproc) php -l",
+            "@php vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --diff --dry-run --stop-on-violation --using-cache=no",
+            "@php vendor/bin/phpstan analyse --configuration=phpstan.neon"
+        ]
     }
 }


### PR DESCRIPTION
This PR adds PHP 7.4 to the php-versions matrix in the CI checks - this means the CI check will check the PHP code for syntax errors on versions 7.4, 8.0 and 81.

The PR also adds two convenience composer scripts:

```
composer cs-fix
```

Automatically fixes any coding standards violations - useful to run before committing changes.

```
composer ci-check
```

Runs the linting, coding standards check and static analysis performed in CI locally, so committers can make sure their code passes before pushing or creating a PR.