### PR TITLE
Validate entrypoints file before using it

### DIFF
--- a/src/Asset/EntrypointsLookup.php
+++ b/src/Asset/EntrypointsLookup.php
@@ -14,8 +14,14 @@ class EntrypointsLookup
         if (!file_exists($entrypointsFilePath)) {
             return;
         }
-        $this->fileExist = true;
+
         $fileInfos = json_decode(file_get_contents($entrypointsFilePath), true);
+
+        if (!isset($fileInfos['isProd'], $fileInfos['entryPoints'], $fileInfos['viteServer'])) {
+            return;
+        }
+
+        $this->fileExist = true;
 
         $this->isProd = $fileInfos['isProd'];
         $this->entriesData = $fileInfos['entryPoints'];


### PR DESCRIPTION
This PR checks that the specific array keys used in `entrypoints.json` exist before assuming the file exists/is valid.

When migrating an existing project from Webpack Encore to this bundle, the `entrypoints.json` file can already exist but in Webpack's format. This causes the following error during the cache warmup after running `composer require pentatrion/vite-bundle`:

```
 // Warming up the cache for the dev environment with debug true                                                        


In EntrypointsLookup.php line 21:
                                         
  [ErrorException]                       
  Warning: Undefined array key "isProd"
```