### PR TITLE
Use array_diff instead of isset to check for required keys in entrypoints file

### DIFF
--- a/src/Asset/EntrypointsLookup.php
+++ b/src/Asset/EntrypointsLookup.php
@@ -17,7 +17,9 @@ class EntrypointsLookup
 
         $fileInfos = json_decode(file_get_contents($entrypointsFilePath), true);
 
-        if (!isset($fileInfos['isProd'], $fileInfos['entryPoints'], $fileInfos['viteServer'])) {
+        $requiredKeysDiff = array_diff(['isProd', 'entryPoints', 'viteServer'], array_keys($fileInfos));
+
+        if (\count($requiredKeysDiff) > 0) {
             return;
         }
 


### PR DESCRIPTION
Somebody commented on my PR #24 that it broke their production build because `viteServer` was null but `isset` returns true for null values. Not sure why but they have since deleted the comment. I still have it in my emails:

![Screenshot from 2022-09-29 10-11-40](https://user-images.githubusercontent.com/6660584/192991634-fe8f3752-6022-410f-a275-e18fc13b17a1.png)

Anyway, this PR use `array_diff` on the keys instead and returns false if one of the required keys is missing from the array, regardless of its value.