### PR TITLE
Update readme with last config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,14 +311,6 @@ export default defineConfig({
 });
 ```
 
-```yaml
-# config/packages/pentatrion_vite.yaml
-pentatrion_vite:
-    # Server options
-    server:
-        https: true
-```
-
 ```console
 npm run dev
 symfony serve


### PR DESCRIPTION
Server was removed from config in https://github.com/lhapaipai/vite-bundle/commit/cf7bd77e03a0462b874daaed7dfe96c94dce82d6 so there's no point of still having it in readme