### PR TITLE
Expose vite_entry_js_files and vite_entry_css_files twig variables

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -38,6 +38,7 @@ services:
         tags: ["twig.extension"]
         arguments:
             - "@vite.entrypoint_renderer"
+            - "@vite.entrypoints_lookup"
 
     Pentatrion\ViteBundle\Controller\ViteController:
         tags: ["controller.service_arguments"]

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -3,24 +3,29 @@
 namespace Pentatrion\ViteBundle\Twig;
 
 use Pentatrion\ViteBundle\Asset\EntrypointRenderer;
+use Pentatrion\ViteBundle\Asset\EntrypointsLookup;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class EntryFilesTwigExtension extends AbstractExtension
 {
-    private $entrypointRenderer;
+    private EntrypointRenderer $entrypointRenderer;
+    private EntrypointsLookup $entrypointsLookup;
 
-    public function __construct(EntrypointRenderer $entrypointRenderer)
+    public function __construct(EntrypointRenderer $entrypointRenderer, EntrypointsLookup $entrypointsLookup)
     {
         $this->entrypointRenderer = $entrypointRenderer;
+        $this->entrypointsLookup = $entrypointsLookup;
     }
 
     public function getFunctions(): array
     {
         return [
-      new TwigFunction('vite_entry_script_tags', [$this, 'renderViteScriptTags'], ['is_safe' => ['html']]),
-      new TwigFunction('vite_entry_link_tags', [$this, 'renderViteLinkTags'], ['is_safe' => ['html']]),
-    ];
+          new TwigFunction('vite_entry_script_tags', [$this, 'renderViteScriptTags'], ['is_safe' => ['html']]),
+          new TwigFunction('vite_entry_link_tags', [$this, 'renderViteLinkTags'], ['is_safe' => ['html']]),
+          new TwigFunction('vite_entry_js_files', [$this, 'getJSFiles']),
+          new TwigFunction('vite_entry_css_files', [$this, 'getCSSFiles']),
+        ];
     }
 
     public function renderViteScriptTags(string $entryName, array $options = [], $buildName = null): string
@@ -31,5 +36,15 @@ class EntryFilesTwigExtension extends AbstractExtension
     public function renderViteLinkTags(string $entryName, array $options = [], $buildName = null): string
     {
         return $this->entrypointRenderer->renderLinks($entryName, $options, $buildName);
+    }
+
+    public function getJSFiles(string $entryName, ?string $buildName = null): array
+    {
+        return $this->entrypointsLookup->getJSFiles($entryName, $buildName);
+    }
+
+    public function getCSSFiles(string $entryName, ?string $buildName = null): array
+    {
+        return $this->entrypointsLookup->getCSSFiles($entryName, $buildName);
     }
 }


### PR DESCRIPTION
The goal of this PR is to expose `vite_entry_js_files` and `vite_entry_css_files` twig variables. This is inspired by Webpack Encore bundle exposing the `encore_entry_js_files` and `encore_entry_css_files` variables. These variables contains an array of all JS / CSS files. This way we can iterate on the files directly in Twig when we need specific behaviour around them.

My personal use case is to be able to have absolute URLs because I render pages in a headless chrome context in which relative URLs can't be resolved. What these two variables would allow me to do is:

```twig
    {% for file in vite_entry_css_files("app") %}
        <link href="{{ absolute_url(asset(file.path)) }}" rel="stylesheet" />
    {% endfor %}

    {% for file in vite_entry_js_files("app") %}
        <script type="module" src="{{ absolute_url(asset(file.path)) }}"></script>
    {% endfor %}
```