### PR TITLE
Add absoluteURL option

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -26,6 +26,7 @@ services:
         arguments:
             - "@vite.entrypoints_lookup"
             - "@vite.tag_renderer"
+            - "@?router"
         public: true
 
     Pentatrion\ViteBundle\Asset\EntrypointRenderer:


### PR DESCRIPTION
This is a replacement of #59. The goal is to provide a new option for `vite_entry_link_tags` and `vite_entry_script_tags` Twig functions: `absoluteURL`. When passed `true`, the rendered link and script tags use an absolute URL (if possible, see below).

My use case is rendering a twig template as static HTML in a headless Chrome instance. There is no URL in this case, so the browser can't get the full URL of the CSS and JS file. Thus I need absolute URLs.

To achieve this, we inject the router service if it's available. If no router has been injected, we return relative path even if `absoluteURL` is true. Also, when using the Vite dev server, we just use the path provided as it should already be an absolute URL.

Here is an example:

```twig
{{ vite_entry_link_tags(entrypoint, { absoluteURL: true }) }}
{{ vite_entry_script_tags(entrypoint, { dependency: "react", absoluteURL: true }) }}
```