### PR TITLE
Fix #69 new entrypoint item shape in EntrypointsLookup::getLegacyJSFile

### DIFF
--- a/src/Asset/EntrypointsLookup.php
+++ b/src/Asset/EntrypointsLookup.php
@@ -118,7 +118,7 @@ class EntrypointsLookup
 
         $legacyEntryName = $entryInfos['entryPoints'][$entryName]['legacy'];
 
-        return $entryInfos['entryPoints'][$legacyEntryName]['js'][0];
+        return $entryInfos['entryPoints'][$legacyEntryName]['js'][0]['path'];
     }
 
     private function throwIfEntryIsMissing(string $entryName, string $buildName = null): void


### PR DESCRIPTION
Since vite-plugin-symfony:4.0.0 (SRI feature) entrypoint item is an array with 'path' and 'hash' instead of a string