### PR TITLE
No duplicate modulepreload tags

### DIFF
--- a/src/Asset/EntrypointRenderer.php
+++ b/src/Asset/EntrypointRenderer.php
@@ -114,7 +114,7 @@ class EntrypointRenderer
         }
 
         if ($this->entrypointsLookup->isProd($buildName)) {
-            foreach ($this->entrypointsLookup->getJavascriptDependencies($entryName, $buildName, $this->returnedPreloadedScripts) as $fileWithHash) {
+            foreach ($this->entrypointsLookup->getJavascriptDependencies($entryName, $buildName) as $fileWithHash) {
                 $content[] = $this->tagRenderer->renderLinkPreload($fileWithHash['path'], [
                     'integrity' => $fileWithHash['hash'],
                 ], $buildName);
@@ -123,7 +123,7 @@ class EntrypointRenderer
 
         if ($this->entrypointsLookup->isProd($buildName) && isset($options['preloadDynamicImports']) && true === $options['preloadDynamicImports']) {
             foreach ($this->entrypointsLookup->getJavascriptDynamicDependencies($entryName, $buildName) as $fileWithHash) {
-                if (in_array($this->returnedPreloadedScripts, $fileWithHash['path'], true) === false) {
+                if (in_array($fileWithHash['path'], $this->returnedPreloadedScripts, true) === false) {
                     $content[] = $this->tagRenderer->renderLinkPreload($fileWithHash['path'], [
                         'integrity' => $fileWithHash['hash'],
                     ], $buildName);

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -18,10 +18,10 @@ class EntryFilesTwigExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-      new TwigFunction('vite_entry_script_tags', [$this, 'renderViteScriptTags'], ['is_safe' => ['html']]),
-      new TwigFunction('vite_entry_link_tags', [$this, 'renderViteLinkTags'], ['is_safe' => ['html']]),
-      new TwigFunction('vite_mode', [$this, 'getViteMode']),
-    ];
+            new TwigFunction('vite_entry_script_tags', [$this, 'renderViteScriptTags'], ['is_safe' => ['html']]),
+            new TwigFunction('vite_entry_link_tags', [$this, 'renderViteLinkTags'], ['is_safe' => ['html']]),
+            new TwigFunction('vite_mode', [$this, 'getViteMode']),
+        ];
     }
 
     public function getViteMode(string $buildName = null): ?string


### PR DESCRIPTION
With multiple entrypoints that may reference some of the same modules, the `vite_entry_link_tags` twig command will render `modulepreload` tags for those modules on each entrypoint that uses those modules, even if that module has already been included in a different entrypoint that has already been rendered via Twig.

This PR aims to fix that (issue #72)