### PR TITLE
Skip devServer lookup if proxy is defined

### DIFF
--- a/src/Controller/ViteController.php
+++ b/src/Controller/ViteController.php
@@ -18,6 +18,22 @@ class ViteController
 
     public function proxyBuild(string $path, ?string $configName = null): Response
     {
+        $origin = $this->proxyOrigin ?? resolveDevServer($configName);
+
+        $response = $this->httpClient->request(
+            'GET',
+            $origin.$base.$path
+        );
+
+        $content = $response->getContent();
+        $statusCode = $response->getStatusCode();
+        $headers = $response->getHeaders();
+
+        return new Response($content, $statusCode, $headers);
+    }
+
+    private function resolveDevServer(?string $configName = null): string
+    {
         if (is_null($configName)) {
             $configName = $this->defaultConfig;
         }
@@ -31,17 +47,6 @@ class ViteController
             throw new \Exception('Vite dev server not available');
         }
 
-        $origin = $this->proxyOrigin ?? $viteDevServer;
-
-        $response = $this->httpClient->request(
-            'GET',
-            $origin.$base.$path
-        );
-
-        $content = $response->getContent();
-        $statusCode = $response->getStatusCode();
-        $headers = $response->getHeaders();
-
-        return new Response($content, $statusCode, $headers);
+        return $viteDevServer;
     }
 }


### PR DESCRIPTION
There is no need to resolve the dev server if a proxy is defined, because we would not use that value.

The check in itself is useless if we use a proxy as the dev server lookup may resolve to null even though it is perfectly accessible via proxy.